### PR TITLE
:adhesive_bandage: Debería forzarse color negro en los CalcTextField

### DIFF
--- a/SeaShellCalculator/app/src/main/java/com/proyectoPdm/seashellinc/presentation/ui/components/CalcTextField.kt
+++ b/SeaShellCalculator/app/src/main/java/com/proyectoPdm/seashellinc/presentation/ui/components/CalcTextField.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
@@ -81,7 +82,11 @@ fun CalcTextField(
                 focusedIndicatorColor = MainBlue,
                 unfocusedIndicatorColor = MainBlue,
                 disabledIndicatorColor = MainBlue,
-                disabledTextColor = CitrineBrown
+                disabledTextColor = CitrineBrown,
+
+                // esto debería forzar a utilizar negro, en vez de por defecto (que podría ser blanco)
+                focusedTextColor = Color.Black,
+                unfocusedTextColor = Color.Black
             ),
             textStyle = TextStyle(
                 fontWeight = if (!enable) FontWeight.Bold else FontWeight.Normal


### PR DESCRIPTION
Dado que no se especificaba color negro para CalcTextField, se usaba el color por defecto del teléfono. En mi caso, era negro; pero en el caso del teléfono de Diego, era blanco. Eso es un problema.
Ahora, se fuerza el color negro completando más parámetros para el TextField del componente.

Esto es muy estúpido, XD.